### PR TITLE
Add revokeForContract and revokeForToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 Welcome! If you're a programmer, view [the specific registry code here](src/DelegationRegistry.sol). If you want to discuss specific open questions, click on the "Issues" tab to leave a comment. If you're interested in integrating this standard into your NFT project or marketplace, we're in the process of creating example templates - or reach out directly via a [Twitter DM](https://twitter.com/0xfoobar).
 
-We have an exciting group of initial people circling around this standard, including foobar (hi!), punk6529 (open metaverse), loopify (loopiverse), andy8052 (fractional), purplehat (artblocks), emiliano (nftrentals), arran (proof), james (collabland), john (gnosis safe), tally labs and many more. The dream is to move from a fragmented world where no individual deployment gets serious use to a global registry where users can register their vault once and use it safely for a variety of airdrops & other claims! Please reach out if interested in helping make this a reality on either the technical, social, or integration side.
+We have an exciting group of initial people circling around this standard, including foobar (hi!), punk6529 (open metaverse), loopify (loopiverse), andy8052 (fractional), purplehat (artblocks), emiliano (nftrentals), arran (proof), james (collabland), john (gnosis safe), wwhchung (manifoldxyz) tally labs and many more. The dream is to move from a fragmented world where no individual deployment gets serious use to a global registry where users can register their vault once and use it safely for a variety of airdrops & other claims! Please reach out if interested in helping make this a reality on either the technical, social, or integration side.
 
 
-## Why NFT delegation?
+## Why delegation?
 
 Proving ownership of an asset to a third party application in the Ethereum ecosystem is common. Common examples include claiming airdrops, minting from collection whitelists, and verifying token ownership for a gated discord/telegram channel. Users frequently sign payloads of data to authenticate themselves before gaining access to perform some operation. However, this introduces the danger of accidentally signing a malicious transaction from a cold wallet vault.
 
@@ -51,6 +51,5 @@ Please open an issue or pull request if you have ideas or code for how to addres
 
 Can we get onchain enumeration?  
 Can we get multiple delegation?  
-Can we get all-at-once revocation?  
 Can we get timelocked delegation?  
 Does the ENS fuse wrapper match what we're doing here?  

--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -3,76 +3,77 @@
 pragma solidity ^0.8.16;
 
 import {EnumerableSet} from "openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";
+import {ERC165} from "openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";
+import {IDelegationRegistry} from "./IDelegationRegistry.sol";
 
 /** 
 * @title An immutable registry contract to be deployed as a standalone primitive
-* @author foobar
 * @dev New project launches can read previous cold wallet -> hot wallet delegations from here and integrate those permissions into their flow
+* contributors: foobar (0xfoobar), punk6529 (open metaverse), loopify (loopiverse), andy8052 (fractional), purplehat (artblocks), emiliano (nftrentals),
+*               arran (proof), james (collabland), john (gnosis safe), wwhchung (manifoldxyz) tally labs and many more
 */
 
-contract DelegationRegistry {
+contract DelegationRegistry is IDelegationRegistry, ERC165 {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /// @notice The global mapping and single source of truth for delegations
-    mapping(bytes32 => bool) public delegations;  
+    mapping(bytes32 => bool) private delegations;
+
+    /// @notice A mapping of wallets to versions (for cheap revocation)
+    mapping(address => uint256) private vaultVersion;
+
+    /// @notice A mapping of wallets to delegates to versions (for cheap revocation)
+    mapping(address => mapping(address => uint256)) private delegateVersion;
 
     /// @notice A secondary mapping to return onchain enumerability of wallet-level delegations
-    mapping(address => EnumerableSet.AddressSet) internal delegationsForAll;
+    /// @notice vault -> vaultVersion -> delegates
+    mapping(address => mapping (uint256 => EnumerableSet.AddressSet)) private delegationsForAll;
 
     /// @notice A secondary mapping to return onchain enumerability of contract-level delegations
-    mapping(address => mapping(address => EnumerableSet.AddressSet)) internal delegationsForContract;
+    /// @notice vault -> vaultVersion -> contract -> delegates
+    mapping(address => mapping (uint256 => mapping(address => EnumerableSet.AddressSet))) private delegationsForContract;
 
     /// @notice A secondary mapping to return onchain enumerability of token-level delegations
-    mapping(address => mapping(address => mapping(uint256 => EnumerableSet.AddressSet))) internal delegationsForToken;
+    /// @notice vault -> vaultVersion -> contract -> tokenId -> delegates
+    mapping(address => mapping (uint256 => mapping(address => mapping(uint256 => EnumerableSet.AddressSet)))) internal delegationsForToken;
 
-    /// @notice Emitted when a user delegates their entire wallet
-    event DelegateForAll(address vault, address delegate, bool value);
-    
-    /// @notice Emitted when a user delegates a specific contract
-    event DelegateForContract(address vault, address delegate, address contract_, bool value);
-
-    /// @notice Emitted when a user delegates a specific token
-    event DelegateForToken(address vault, address delegate, address contract_, uint256 tokenId, bool value);
+    /** 
+    * See {IERC165-supportsInterface}.
+    */
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165) returns (bool) {
+        return interfaceId == type(IDelegationRegistry).interfaceId || super.supportsInterface(interfaceId);
+    }
 
     /** -----------  WRITE ----------- */
 
     /** 
-    * @notice Allow the delegate to act on your behalf for all NFT contracts
-    * @param delegate The hotwallet to act on your behalf
-    * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+    * See {IDelegationRegistry-delegateForAll}.
     */
-    function delegateForAll(address delegate, bool value) external {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, msg.sender));
+    function delegateForAll(address delegate, bool value) external override {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, msg.sender, vaultVersion[msg.sender], delegateVersion[msg.sender][delegate]));
         delegations[delegateHash] = value;
-        _setDelegationEnumeration(delegationsForAll[msg.sender], delegate, value);
-        emit DelegateForAll(msg.sender, delegate, value);
+        _setDelegationEnumeration(delegationsForAll[msg.sender][vaultVersion[msg.sender]], delegate, value);
+        emit IDelegationRegistry.DelegateForAll(msg.sender, delegate, value);
     }
 
     /** 
-    * @notice Allow the delegate to act on your behalf for a specific NFT contract
-    * @param delegate The hotwallet to act on your behalf
-    * @param contract_ The address for the contract you're delegating
-    * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+    * See {IDelegationRegistry-delegateForContract}.
     */
-    function delegateForContract(address delegate, address contract_, bool value) external {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, msg.sender, contract_));
+    function delegateForContract(address delegate, address contract_, bool value) external override {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, msg.sender, contract_, vaultVersion[msg.sender], delegateVersion[msg.sender][delegate]));
         delegations[delegateHash] = value;
-        _setDelegationEnumeration(delegationsForContract[msg.sender][contract_], delegate, value);
-        emit DelegateForContract(msg.sender, delegate, contract_, value);
+        _setDelegationEnumeration(delegationsForContract[msg.sender][vaultVersion[msg.sender]][contract_], delegate, value);
+        emit IDelegationRegistry.DelegateForContract(msg.sender, delegate, contract_, value);
     }
 
     /** 
-    * @notice Allow the delegate to act on your behalf for a specific token, supports 721 and 1155
-    * @param delegate The hotwallet to act on your behalf
-    * @param contract_ The address for the contract you're delegating
-    * @param tokenId The token id for the token you're delegating
-    * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+    * See {IDelegationRegistry-delegateForToken}.
     */
-    function delegateForToken(address delegate, address contract_, uint256 tokenId, bool value) external {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, msg.sender, contract_, tokenId));
+    function delegateForToken(address delegate, address contract_, uint256 tokenId, bool value) external override {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, msg.sender, contract_, tokenId, vaultVersion[msg.sender], delegateVersion[msg.sender][delegate]));
         delegations[delegateHash] = value;
-        _setDelegationEnumeration(delegationsForToken[msg.sender][contract_][tokenId], delegate, value);
-        emit DelegateForToken(msg.sender, delegate, contract_, tokenId, value);
+        _setDelegationEnumeration(delegationsForToken[msg.sender][vaultVersion[msg.sender]][contract_][tokenId], delegate, value);
+        emit IDelegationRegistry.DelegateForToken(msg.sender, delegate, contract_, tokenId, value);
     }
 
     function _setDelegationEnumeration(EnumerableSet.AddressSet storage set, address key, bool value) internal {
@@ -83,68 +84,108 @@ contract DelegationRegistry {
         }
     }
 
+    /**
+    * See {IDelegationRegistry-revokeAllDelegates}.
+    */
+    function revokeAllDelegates() external override {
+        vaultVersion[msg.sender]++;
+        emit IDelegationRegistry.RevokeAllDelegates(msg.sender);
+    }
+
+     /**
+    * See {IDelegationRegistry-revokeDelegate}.
+    */
+    function revokeDelegate(address delegate) external override {
+        delegateVersion[msg.sender][delegate]++;
+        // Remove delegate from enumerations
+        delegationsForAll[msg.sender][vaultVersion[msg.sender]].remove(delegate);
+        // For delegationsForContract and delegationsForToken, filter in the view
+        // functions
+        emit IDelegationRegistry.RevokeDelegate(msg.sender, delegate);
+    }
+
     /** -----------  READ ----------- */
 
     /**
-    * @notice Returns an array of wallet-level delegations for a given vault
-    * @param vault The cold wallet who issued the delegation
-    * @return addresses Array of wallet-level delegations for a given vault
+    * See {IDelegationRegistry-getDelegationsForAll}.
     */
     function getDelegationsForAll(address vault) external view returns (address[] memory) {
-        return delegationsForAll[vault].values();
+        return delegationsForAll[vault][vaultVersion[vault]].values();
     }
 
     /**
-    * @notice Returns an array of contract-level delegations for a given vault and contract
-    * @param vault The cold wallet who issued the delegation
-    * @param contract_ The address for the contract you're delegating
-    * @return addresses Array of contract-level delegations for a given vault and contract
+    * See {IDelegationRegistry-getDelegationsForContract}.
     */
-    function getDelegationsForContract(address vault, address contract_) external view returns (address[] memory) {
-        return delegationsForContract[vault][contract_].values();
+    function getDelegationsForContract(address vault, address contract_) external view override returns (address[] memory delegates) {
+        EnumerableSet.AddressSet storage potentialDelegates = delegationsForContract[vault][vaultVersion[vault]][contract_];
+        uint256 potentialDelegatesLength = potentialDelegates.length();
+        uint256 delegateCount = 0;
+        delegates = new address[](potentialDelegatesLength);
+        for (uint256 i = 0; i < potentialDelegatesLength;) {
+            if (checkDelegateForContract(potentialDelegates.at(i), vault, contract_)) {
+                delegates[delegateCount] = potentialDelegates.at(i);
+                delegateCount++;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        if (potentialDelegatesLength > delegateCount) {
+            assembly { 
+                let decrease := sub(potentialDelegatesLength, delegateCount)
+                mstore(delegates, sub(mload(delegates), decrease))
+            }
+        }
     }
 
     /**
-    * @notice Returns an array of contract-level delegations for a given vault's token
-    * @param vault The cold wallet who issued the delegation
-    * @param contract_ The address for the contract holding the token
-    * @param tokenId The token id for the token you're delegating
-    * @return addresses Array of contract-level delegations for a given vault's token
+    * See {IDelegationRegistry-getDelegationsForToken}.
     */
-    function getDelegationsForToken(address vault, address contract_, uint256 tokenId) external view returns (address[] memory) {
-        return delegationsForToken[vault][contract_][tokenId].values();
+    function getDelegationsForToken(address vault, address contract_, uint256 tokenId) external view override returns (address[] memory delegates) {
+        // Since we cannot easily invalidate delegates on the enumeration (see revokeDelegates)
+        // we will need to filter out invalid entries
+        EnumerableSet.AddressSet storage potentialDelegates = delegationsForToken[vault][vaultVersion[vault]][contract_][tokenId];
+        uint256 potentialDelegatesLength = potentialDelegates.length();
+        uint256 delegateCount = 0;
+        delegates = new address[](potentialDelegatesLength);
+        for (uint256 i = 0; i < potentialDelegatesLength;) {
+            if (checkDelegateForToken(potentialDelegates.at(i), vault, contract_, tokenId)) {
+                delegates[delegateCount] = potentialDelegates.at(i);
+                delegateCount++;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        if (potentialDelegatesLength > delegateCount) {
+            assembly { 
+                let decrease := sub(potentialDelegatesLength, delegateCount)
+                mstore(delegates, sub(mload(delegates), decrease))
+            }
+        }
     }
 
     /** 
-    * @notice Returns true if the address is delegated to act on your behalf for all NFTs
-    * @param delegate The hotwallet to act on your behalf
-    * @param vault The cold wallet who issued the delegation
+    * See {IDelegationRegistry-checkDelegateForAll}.
     */
-    function checkDelegateForAll(address delegate, address vault) public view returns (bool) {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, vault));
+    function checkDelegateForAll(address delegate, address vault) public view override returns (bool) {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, vault, vaultVersion[vault], delegateVersion[vault][delegate]));
         return delegations[delegateHash];
     }
 
     /** 
-    * @notice Returns true if the address is delegated to act on your behalf for an NFT contract
-    * @param delegate The hotwallet to act on your behalf
-    * @param contract_ The address for the contract you're delegating
-    * @param vault The cold wallet who issued the delegation
+    * See {IDelegationRegistry-checkDelegateForAll}.
     */ 
-    function checkDelegateForContract(address delegate, address vault, address contract_) public view returns (bool) {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, vault, contract_));
+    function checkDelegateForContract(address delegate, address vault, address contract_) public view override returns (bool) {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, vault, contract_, vaultVersion[vault], delegateVersion[vault][delegate]));
         return delegations[delegateHash] ? true : checkDelegateForAll(delegate, vault);
     }
     
     /** 
-    * @notice Returns true if the address is delegated to act on your behalf for an specific NFT
-    * @param delegate The hotwallet to act on your behalf
-    * @param contract_ The address for the contract you're delegating
-    * @param tokenId The token id for the token you're delegating
-    * @param vault The cold wallet who issued the delegation
+    * See {IDelegationRegistry-checkDelegateForToken}.
     */
-    function checkDelegateForToken(address delegate, address vault, address contract_, uint256 tokenId) public view returns (bool) {
-        bytes32 delegateHash = keccak256(abi.encode(delegate, vault, contract_, tokenId));
+    function checkDelegateForToken(address delegate, address vault, address contract_, uint256 tokenId) public view override returns (bool) {
+        bytes32 delegateHash = keccak256(abi.encode(delegate, vault, contract_, tokenId, vaultVersion[vault], delegateVersion[vault][delegate]));
         return delegations[delegateHash] ? true : checkDelegateForContract(delegate, vault, contract_);
     }
 }

--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -95,16 +95,18 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         emit IDelegationRegistry.RevokeAllDelegates(msg.sender);
     }
 
-     /**
+    /**
     * See {IDelegationRegistry-revokeDelegate}.
     */
     function revokeDelegate(address delegate) external override {
-        delegateVersion[msg.sender][delegate]++;
-        // Remove delegate from enumerations
-        delegationsForAll[msg.sender][vaultVersion[msg.sender]].remove(delegate);
-        // For delegationsForContract and delegationsForToken, filter in the view
-        // functions
-        emit IDelegationRegistry.RevokeDelegate(msg.sender, delegate);
+            _revokeDelegate(delegate, msg.sender);
+    }
+
+    /**
+    * See {IDelegationRegistry-revokeSelf}.
+    */
+    function revokeSelf(address vault) external override {
+        _revokeDelegate(msg.sender, vault);
     }
 
     /** 
@@ -127,6 +129,15 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         emit IDelegationRegistry.RevokeForToken(msg.sender, delegate, contract_, tokenId);
     }
 
+    function _revokeDelegate(address delegate, address vault) internal {
+        delegateVersion[vault][delegate]++;
+        // Remove delegate from enumerations
+        delegationsForAll[vault][vaultVersion[vault]].remove(delegate);
+        // For delegationsForContract and delegationsForToken, filter in the view
+        // functions
+        emit IDelegationRegistry.RevokeDelegate(vault, msg.sender);
+    }
+    
     /** -----------  READ ----------- */
 
     /**

--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -13,39 +13,25 @@ import {EnumerableSet} from "openzeppelin-contracts/contracts/utils/structs/Enum
 contract DelegationRegistry {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    /** 
-    * @notice The global mapping and single source of truth for delegations
-    */
+    /// @notice The global mapping and single source of truth for delegations
     mapping(bytes32 => bool) public delegations;  
 
-    /**
-    * @notice A secondary mapping to return onchain enumerability of wallet-level delegations
-    */
+    /// @notice A secondary mapping to return onchain enumerability of wallet-level delegations
     mapping(address => EnumerableSet.AddressSet) internal delegationsForAll;
 
-    /**
-    * @notice A secondary mapping to return onchain enumerability of collection-level delegations
-    */
+    /// @notice A secondary mapping to return onchain enumerability of collection-level delegations
     mapping(address => mapping(address => EnumerableSet.AddressSet)) internal delegationsForCollection;
 
-    /**
-    * @notice A secondary mapping to return onchain enumerability of token-level delegations
-    */
+    /// @notice A secondary mapping to return onchain enumerability of token-level delegations
     mapping(address => mapping(address => mapping(uint256 => EnumerableSet.AddressSet))) internal delegationsForToken;
 
-    /** 
-    * @notice Emitted when a user delegates their entire wallet
-    */
+    /// @notice Emitted when a user delegates their entire wallet
     event DelegateForAll(address vault, address delegate, bool value);
     
-    /** 
-    * @notice Emitted when a user delegates a specific collection
-    */ 
+    /// @notice Emitted when a user delegates a specific collection
     event DelegateForCollection(address vault, address delegate, address collection, bool value);
 
-    /** 
-    * @notice Emitted when a user delegates a specific token
-    */
+    /// @notice Emitted when a user delegates a specific token
     event DelegateForToken(address vault, address delegate, address collection, uint256 tokenId, bool value);
 
     /** -----------  WRITE ----------- */
@@ -54,7 +40,7 @@ contract DelegationRegistry {
     * @notice Allow the delegate to act on your behalf for all NFT collections
     * @param delegate The hotwallet to act on your behalf
     * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
-    */ 
+    */
     function delegateForAll(address delegate, bool value) external {
         bytes32 delegateHash = keccak256(abi.encode(delegate, msg.sender));
         delegations[delegateHash] = value;

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -12,44 +12,50 @@ pragma solidity ^0.8.16;
 interface IDelegationRegistry {
 
     /// @notice Emitted when a user delegates their entire wallet
-    event DelegateForAll(address vault, address delegate, bool value);
+    event DelegateForAll(address vault, address delegate, uint256 expiry);
     
     /// @notice Emitted when a user delegates a specific contract
-    event DelegateForContract(address vault, address delegate, address contract_, bool value);
+    event DelegateForContract(address vault, address delegate, address contract_, uint256 expiry);
 
     /// @notice Emitted when a user delegates a specific token
-    event DelegateForToken(address vault, address delegate, address contract_, uint256 tokenId, bool value);
+    event DelegateForToken(address vault, address delegate, address contract_, uint256 tokenId, uint256 expiry);
 
     /// @notice Emitted when a user revokes all delegations
     event RevokeAllDelegates(address vault);
 
     /// @notice Emitted when a user revoes all delegations for a given delegate
     event RevokeDelegate(address vault, address delegate);
+    
+    /// @notice Emitted when a user revokes a specific contract
+    event RevokeForContract(address vault, address delegate, address contract_);
+
+    /// @notice Emitted when a user revokes a specific token
+    event RevokeForToken(address vault, address delegate, address contract_, uint256 tokenId);
 
     /** -----------  WRITE ----------- */
 
     /** 
     * @notice Allow the delegate to act on your behalf for all contracts
     * @param delegate The hotwallet to act on your behalf
-    * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+    * @param expiry The expiration timestamp of this delegation
     */
-    function delegateForAll(address delegate, bool value) external;
+    function delegateForAll(address delegate, uint256 expiry) external;
 
     /** 
     * @notice Allow the delegate to act on your behalf for a specific contract
     * @param delegate The hotwallet to act on your behalf
     * @param contract_ The address for the contract you're delegating
-    * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+    * @param expiry The expiration timestamp of this delegation
     */
-    function delegateForContract(address delegate, address contract_, bool value) external;
+    function delegateForContract(address delegate, address contract_, uint256 expiry) external;
     /** 
     * @notice Allow the delegate to act on your behalf for a specific token, supports 721 and 1155
     * @param delegate The hotwallet to act on your behalf
     * @param contract_ The address for the contract you're delegating
     * @param tokenId The token id for the token you're delegating
-    * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+    * @param expiry The expiration timestamp of this delegation
     */
-    function delegateForToken(address delegate, address contract_, uint256 tokenId, bool value) external;
+    function delegateForToken(address delegate, address contract_, uint256 tokenId, uint256 expiry) external;
 
     /**
      * @notice Revoke all delegates
@@ -57,9 +63,27 @@ interface IDelegationRegistry {
     function revokeAllDelegates() external;
 
     /**
-     * @notice Revoke a specific delegate for all their permissions
+     * @notice Revoke a specific delegate for all their permissions.
+     *         Opposite of delegateForAll(address delegate, uint256 expiry)
      */
     function revokeDelegate(address delegate) external;
+
+    /** 
+    * @notice Prevent the delegate to act on your behalf for a specific contract.
+    *         Opposite of delegateForContract(address delegate, address contract_, uint256 expiry)
+    * @param delegate The hotwallet that could act on your behalf
+    * @param contract_ The address for the contract you're revoking
+    */
+    function revokeForContract(address delegate, address contract_) external;
+    
+    /** 
+    * @notice Prevent the delegate to act on your behalf for a specific token, supports 721 and 1155
+    *         Opposite of delegateForToken(address delegate, address contract_, uint256 tokenId, uint256 expiry)
+    * @param delegate The hotwallet that could on your behalf
+    * @param contract_ The address for the contract you're revoking
+    * @param tokenId The token id for the token you're revoking
+    */
+    function revokeForToken(address delegate, address contract_, uint256 tokenId) external;
 
     /** -----------  READ ----------- */
 

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -68,6 +68,11 @@ interface IDelegationRegistry {
      */
     function revokeDelegate(address delegate) external;
 
+    /**
+     * @notice Revoke delegation for a specific vault, for all permissions
+     */
+    function revokeSelf(address vault) external;
+
     /** 
     * @notice Prevent the delegate to act on your behalf for a specific contract.
     *         Opposite of delegateForContract(address delegate, address contract_, uint256 expiry)

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.16;
+
+/** 
+* @title An immutable registry contract to be deployed as a standalone primitive
+* @dev New project launches can read previous cold wallet -> hot wallet delegations from here and integrate those permissions into their flow
+* contributors: foobar (0xfoobar), punk6529 (open metaverse), loopify (loopiverse), andy8052 (fractional), purplehat (artblocks), emiliano (nftrentals),
+*               arran (proof), james (collabland), john (gnosis safe), wwhchung (manifoldxyz) tally labs and many more
+*/
+
+interface IDelegationRegistry {
+
+    /// @notice Emitted when a user delegates their entire wallet
+    event DelegateForAll(address vault, address delegate, bool value);
+    
+    /// @notice Emitted when a user delegates a specific contract
+    event DelegateForContract(address vault, address delegate, address contract_, bool value);
+
+    /// @notice Emitted when a user delegates a specific token
+    event DelegateForToken(address vault, address delegate, address contract_, uint256 tokenId, bool value);
+
+    /// @notice Emitted when a user revokes all delegations
+    event RevokeAllDelegates(address vault);
+
+    /// @notice Emitted when a user revoes all delegations for a given delegate
+    event RevokeDelegate(address vault, address delegate);
+
+    /** -----------  WRITE ----------- */
+
+    /** 
+    * @notice Allow the delegate to act on your behalf for all contracts
+    * @param delegate The hotwallet to act on your behalf
+    * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+    */
+    function delegateForAll(address delegate, bool value) external;
+
+    /** 
+    * @notice Allow the delegate to act on your behalf for a specific contract
+    * @param delegate The hotwallet to act on your behalf
+    * @param contract_ The address for the contract you're delegating
+    * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+    */
+    function delegateForContract(address delegate, address contract_, bool value) external;
+    /** 
+    * @notice Allow the delegate to act on your behalf for a specific token, supports 721 and 1155
+    * @param delegate The hotwallet to act on your behalf
+    * @param contract_ The address for the contract you're delegating
+    * @param tokenId The token id for the token you're delegating
+    * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+    */
+    function delegateForToken(address delegate, address contract_, uint256 tokenId, bool value) external;
+
+    /**
+     * @notice Revoke all delegates
+     */
+    function revokeAllDelegates() external;
+
+    /**
+     * @notice Revoke a specific delegate for all their permissions
+     */
+    function revokeDelegate(address delegate) external;
+
+    /** -----------  READ ----------- */
+
+    /**
+    * @notice Returns an array of wallet-level delegations for a given vault
+    * @param vault The cold wallet who issued the delegation
+    * @return addresses Array of wallet-level delegations for a given vault
+    */
+    function getDelegationsForAll(address vault) external view returns (address[] memory);
+
+    /**
+    * @notice Returns an array of contract-level delegations for a given vault and contract
+    * @param vault The cold wallet who issued the delegation
+    * @param contract_ The address for the contract you're delegating
+    * @return addresses Array of contract-level delegations for a given vault and contract
+    */
+    function getDelegationsForContract(address vault, address contract_) external view returns (address[] memory);
+
+    /**
+    * @notice Returns an array of contract-level delegations for a given vault's token
+    * @param vault The cold wallet who issued the delegation
+    * @param contract_ The address for the contract holding the token
+    * @param tokenId The token id for the token you're delegating
+    * @return addresses Array of contract-level delegations for a given vault's token
+    */
+    function getDelegationsForToken(address vault, address contract_, uint256 tokenId) external view returns (address[] memory);
+
+    /** 
+    * @notice Returns true if the address is delegated to act on your behalf for all NFTs
+    * @param delegate The hotwallet to act on your behalf
+    * @param vault The cold wallet who issued the delegation
+    */
+    function checkDelegateForAll(address delegate, address vault) external view returns (bool);
+
+    /** 
+    * @notice Returns true if the address is delegated to act on your behalf for an NFT contract
+    * @param delegate The hotwallet to act on your behalf
+    * @param contract_ The address for the contract you're delegating
+    * @param vault The cold wallet who issued the delegation
+    */ 
+    function checkDelegateForContract(address delegate, address vault, address contract_) external view returns (bool);
+    
+    /** 
+    * @notice Returns true if the address is delegated to act on your behalf for an specific NFT
+    * @param delegate The hotwallet to act on your behalf
+    * @param contract_ The address for the contract you're delegating
+    * @param tokenId The token id for the token you're delegating
+    * @param vault The cold wallet who issued the delegation
+    */
+    function checkDelegateForToken(address delegate, address vault, address contract_, uint256 tokenId) external view returns (bool);
+}

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -134,36 +134,81 @@ contract DelegationRegistryTest is Test {
         assertTrue(reg.checkDelegateForToken(delegate1, vault, contract_, tokenId));
     }
 
-    function testApproveAndExpireForAll(address vault, address delegate) public {
+    function testApproveAndExpireForAll(address vault, address delegate0, address delegate1, address contract_, uint256 tokenId) public {
+        vm.assume(vault != delegate0);
+        vm.assume(delegate0 != delegate1);
         // Approve
         vm.startPrank(vault);
-        reg.delegateForAll(delegate, 1234);
-        assertTrue(reg.checkDelegateForAll(delegate, vault));
-        assertTrue(reg.checkDelegateForContract(delegate, vault, address(0x0)));
-        assertTrue(reg.checkDelegateForToken(delegate, vault, address(0x0), 0));
+        reg.delegateForAll(delegate0, 1234);
+        assertTrue(reg.checkDelegateForAll(delegate0, vault));
+        assertTrue(reg.checkDelegateForContract(delegate0, vault, contract_));
+        assertTrue(reg.checkDelegateForToken(delegate0, vault, contract_, tokenId));
+        reg.delegateForAll(delegate1, 5678);
+        assertTrue(reg.checkDelegateForAll(delegate1, vault));
+        assertTrue(reg.checkDelegateForContract(delegate1, vault, contract_));
+        assertTrue(reg.checkDelegateForToken(delegate1, vault, contract_, tokenId));
+
         // Expire
         vm.warp(4321);
-        assertFalse(reg.checkDelegateForAll(delegate, vault));
+
+        // Read
+        address[] memory vaultDelegatesForAll = reg.getDelegationsForAll(vault);
+        assertEq(vaultDelegatesForAll.length, 1);
+        assertEq(vaultDelegatesForAll[0], delegate1);
+
+        assertFalse(reg.checkDelegateForAll(delegate0, vault));
+        assertTrue(reg.checkDelegateForAll(delegate1, vault));
+        assertFalse(reg.checkDelegateForContract(delegate0, vault, contract_));
+        assertTrue(reg.checkDelegateForContract(delegate1, vault, contract_));
+        assertFalse(reg.checkDelegateForToken(delegate0, vault, contract_, tokenId));
+        assertTrue(reg.checkDelegateForToken(delegate1, vault, contract_, tokenId));
     }
 
-    function testApproveAndExpireForContract(address vault, address delegate, address contract_) public {
+    function testApproveAndExpireForContract(address vault, address delegate0, address delegate1, address contract_, uint256 tokenId) public {
+        vm.assume(vault != delegate0);
+        vm.assume(delegate0 != delegate1);
         // Approve
         vm.startPrank(vault);
-        reg.delegateForContract(delegate, contract_, 1234);
-        assertTrue(reg.checkDelegateForContract(delegate, vault, contract_));
-        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, 0));
+        reg.delegateForContract(delegate0, contract_, 1234);
+        assertTrue(reg.checkDelegateForContract(delegate0, vault, contract_));
+        assertTrue(reg.checkDelegateForToken(delegate0, vault, contract_, tokenId));
+        reg.delegateForContract(delegate1, contract_, 5678);
+        assertTrue(reg.checkDelegateForContract(delegate1, vault, contract_));
+        assertTrue(reg.checkDelegateForToken(delegate1, vault, contract_, tokenId));
+
         // Expire
         vm.warp(4321);
-        assertFalse(reg.checkDelegateForContract(delegate, vault, contract_));
+
+        // Read
+        address[] memory vaultDelegatesForContract = reg.getDelegationsForContract(vault, contract_);
+        assertEq(vaultDelegatesForContract.length, 1);
+        assertEq(vaultDelegatesForContract[0], delegate1);
+
+        assertFalse(reg.checkDelegateForContract(delegate0, vault, contract_));
+        assertTrue(reg.checkDelegateForContract(delegate1, vault, contract_));
+        assertFalse(reg.checkDelegateForToken(delegate0, vault, contract_, tokenId));
+        assertTrue(reg.checkDelegateForToken(delegate1, vault, contract_, tokenId));
     }
 
-    function testApproveAndExpireForToken(address vault, address delegate, address contract_, uint256 tokenId) public {
+    function testApproveAndExpireForToken(address vault, address delegate0, address delegate1, address contract_, uint256 tokenId) public {
+        vm.assume(vault != delegate0);
+        vm.assume(delegate0 != delegate1);
         // Approve
         vm.startPrank(vault);
-        reg.delegateForToken(delegate, contract_, tokenId, 1234);
-        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, tokenId));
+        reg.delegateForToken(delegate0, contract_, tokenId, 1234);
+        assertTrue(reg.checkDelegateForToken(delegate0, vault, contract_, tokenId));
+        reg.delegateForToken(delegate1, contract_, tokenId, 5678);
+        assertTrue(reg.checkDelegateForToken(delegate1, vault, contract_, tokenId));
+
         // Expire
         vm.warp(4321);
-        assertFalse(reg.checkDelegateForToken(delegate, vault, contract_, tokenId));
+
+        // Read
+        address[] memory vaultDelegatesForToken = reg.getDelegationsForToken(vault, contract_, tokenId);
+        assertEq(vaultDelegatesForToken.length, 1);
+        assertEq(vaultDelegatesForToken[0], delegate1);
+
+        assertFalse(reg.checkDelegateForToken(delegate0, vault, contract_, tokenId));
+        assertTrue(reg.checkDelegateForToken(delegate1, vault, contract_, tokenId));
     }
 }

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -16,48 +16,48 @@ contract DelegationRegistryTest is Test {
     function testApproveAndRevokeForAll(address vault, address delegate) public {
         // Approve
         vm.startPrank(vault);
-        reg.delegateForAll(delegate, true);
+        reg.delegateForAll(delegate, 1234);
         assertTrue(reg.checkDelegateForAll(delegate, vault));
         assertTrue(reg.checkDelegateForContract(delegate, vault, address(0x0)));
         assertTrue(reg.checkDelegateForToken(delegate, vault, address(0x0), 0));
         // Revoke
-        reg.delegateForAll(delegate, false);
+        reg.revokeDelegate(delegate);
         assertFalse(reg.checkDelegateForAll(delegate, vault));
     }
 
     function testApproveAndRevokeForContract(address vault, address delegate, address contract_) public {
         // Approve
         vm.startPrank(vault);
-        reg.delegateForContract(delegate, contract_, true);
+        reg.delegateForContract(delegate, contract_, 1234);
         assertTrue(reg.checkDelegateForContract(delegate, vault, contract_));
         assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, 0));
         // Revoke
-        reg.delegateForContract(delegate, contract_, false);
+        reg.revokeForContract(delegate, contract_);
         assertFalse(reg.checkDelegateForContract(delegate, vault, contract_));
     }
 
     function testApproveAndRevokeForToken(address vault, address delegate, address contract_, uint256 tokenId) public {
         // Approve
         vm.startPrank(vault);
-        reg.delegateForToken(delegate, contract_, tokenId, true);
+        reg.delegateForToken(delegate, contract_, tokenId, 1234);
         assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, tokenId));
         // Revoke
-        reg.delegateForToken(delegate, contract_, tokenId, false);
+        reg.revokeForToken(delegate, contract_, tokenId);
         assertFalse(reg.checkDelegateForToken(delegate, vault, contract_, tokenId));
     }
 
     function testMultipleDelegationForAll(address vault, address delegate0, address delegate1) public {
         vm.assume(delegate0 != delegate1);
         vm.startPrank(vault);
-        reg.delegateForAll(delegate0, true);
-        reg.delegateForAll(delegate1, true);
+        reg.delegateForAll(delegate0, 1234);
+        reg.delegateForAll(delegate1, 1234);
         // Read
         address[] memory delegates = reg.getDelegationsForAll(vault);
         assertEq(delegates.length, 2);
         assertEq(delegates[0], delegate0);
         assertEq(delegates[1], delegate1);
         // Remove
-        reg.delegateForAll(delegate0, false);
+        reg.revokeDelegate(delegate0);
         delegates = reg.getDelegationsForAll(vault);
         assertEq(delegates.length, 1);
     }
@@ -66,14 +66,14 @@ contract DelegationRegistryTest is Test {
         vm.assume(delegate != vault0);
         vm.assume(vault0 != vault1);
         vm.startPrank(vault0);
-        reg.delegateForAll(delegate, true);
-        reg.delegateForContract(delegate, contract_, true);
-        reg.delegateForToken(delegate, contract_, tokenId, true);
+        reg.delegateForAll(delegate, 1234);
+        reg.delegateForContract(delegate, contract_, 1234);
+        reg.delegateForToken(delegate, contract_, tokenId, 1234);
         vm.stopPrank();
         vm.startPrank(vault1);
-        reg.delegateForAll(delegate, true);
-        reg.delegateForContract(delegate, contract_, true);
-        reg.delegateForToken(delegate, contract_, tokenId, true);
+        reg.delegateForAll(delegate, 1234);
+        reg.delegateForContract(delegate, contract_, 1234);
+        reg.delegateForToken(delegate, contract_, tokenId, 1234);
         vm.stopPrank();
         // Revoke delegates for vault0
         vm.startPrank(vault0);
@@ -105,12 +105,12 @@ contract DelegationRegistryTest is Test {
         vm.assume(vault != delegate0);
         vm.assume(delegate0 != delegate1);
         vm.startPrank(vault);
-        reg.delegateForAll(delegate0, true);
-        reg.delegateForContract(delegate0, contract_, true);
-        reg.delegateForToken(delegate0, contract_, tokenId, true);
-        reg.delegateForAll(delegate1, true);
-        reg.delegateForContract(delegate1, contract_, true);
-        reg.delegateForToken(delegate1, contract_, tokenId, true);
+        reg.delegateForAll(delegate0, 1234);
+        reg.delegateForContract(delegate0, contract_, 1234);
+        reg.delegateForToken(delegate0, contract_, tokenId, 1234);
+        reg.delegateForAll(delegate1, 1234);
+        reg.delegateForContract(delegate1, contract_, 1234);
+        reg.delegateForToken(delegate1, contract_, tokenId, 1234);
         
         // Revoke delegate0
         reg.revokeDelegate(delegate0);
@@ -132,5 +132,38 @@ contract DelegationRegistryTest is Test {
         assertTrue(reg.checkDelegateForContract(delegate1, vault, contract_));
         assertFalse(reg.checkDelegateForToken(delegate0, vault, contract_, tokenId));
         assertTrue(reg.checkDelegateForToken(delegate1, vault, contract_, tokenId));
+    }
+
+    function testApproveAndExpireForAll(address vault, address delegate) public {
+        // Approve
+        vm.startPrank(vault);
+        reg.delegateForAll(delegate, 1234);
+        assertTrue(reg.checkDelegateForAll(delegate, vault));
+        assertTrue(reg.checkDelegateForContract(delegate, vault, address(0x0)));
+        assertTrue(reg.checkDelegateForToken(delegate, vault, address(0x0), 0));
+        // Expire
+        vm.warp(4321);
+        assertFalse(reg.checkDelegateForAll(delegate, vault));
+    }
+
+    function testApproveAndExpireForContract(address vault, address delegate, address contract_) public {
+        // Approve
+        vm.startPrank(vault);
+        reg.delegateForContract(delegate, contract_, 1234);
+        assertTrue(reg.checkDelegateForContract(delegate, vault, contract_));
+        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, 0));
+        // Expire
+        vm.warp(4321);
+        assertFalse(reg.checkDelegateForContract(delegate, vault, contract_));
+    }
+
+    function testApproveAndExpireForToken(address vault, address delegate, address contract_, uint256 tokenId) public {
+        // Approve
+        vm.startPrank(vault);
+        reg.delegateForToken(delegate, contract_, tokenId, 1234);
+        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, tokenId));
+        // Expire
+        vm.warp(4321);
+        assertFalse(reg.checkDelegateForToken(delegate, vault, contract_, tokenId));
     }
 }

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -18,32 +18,32 @@ contract DelegationRegistryTest is Test {
         vm.startPrank(vault);
         reg.delegateForAll(delegate, true);
         assertTrue(reg.checkDelegateForAll(delegate, vault));
-        assertTrue(reg.checkDelegateForCollection(delegate, vault, address(0x0)));
+        assertTrue(reg.checkDelegateForContract(delegate, vault, address(0x0)));
         assertTrue(reg.checkDelegateForToken(delegate, vault, address(0x0), 0));
         // Revoke
         reg.delegateForAll(delegate, false);
         assertFalse(reg.checkDelegateForAll(delegate, vault));
     }
 
-    function testApproveAndRevokeForCollection(address vault, address delegate, address collection) public {
+    function testApproveAndRevokeForContract(address vault, address delegate, address contract_) public {
         // Approve
         vm.startPrank(vault);
-        reg.delegateForCollection(delegate, collection, true);
-        assertTrue(reg.checkDelegateForCollection(delegate, vault, collection));
-        assertTrue(reg.checkDelegateForToken(delegate, vault, collection, 0));
+        reg.delegateForContract(delegate, contract_, true);
+        assertTrue(reg.checkDelegateForContract(delegate, vault, contract_));
+        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, 0));
         // Revoke
-        reg.delegateForCollection(delegate, collection, false);
-        assertFalse(reg.checkDelegateForCollection(delegate, vault, collection));
+        reg.delegateForContract(delegate, contract_, false);
+        assertFalse(reg.checkDelegateForContract(delegate, vault, contract_));
     }
 
-    function testApproveAndRevokeForToken(address vault, address delegate, address collection, uint256 tokenId) public {
+    function testApproveAndRevokeForToken(address vault, address delegate, address contract_, uint256 tokenId) public {
         // Approve
         vm.startPrank(vault);
-        reg.delegateForToken(delegate, collection, tokenId, true);
-        assertTrue(reg.checkDelegateForToken(delegate, vault, collection, tokenId));
+        reg.delegateForToken(delegate, contract_, tokenId, true);
+        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, tokenId));
         // Revoke
-        reg.delegateForToken(delegate, collection, tokenId, false);
-        assertFalse(reg.checkDelegateForToken(delegate, vault, collection, tokenId));
+        reg.delegateForToken(delegate, contract_, tokenId, false);
+        assertFalse(reg.checkDelegateForToken(delegate, vault, contract_, tokenId));
     }
 
     function testMultipleDelegationForAll(address vault, address delegate0, address delegate1) public {


### PR DESCRIPTION
This PR is built on top of the changes implemented in #11 (non-optional expiration logic)

The reason behind this PR comes from this discussion  #12 

This implementation removes the ability to revoke delegations by setting `expiry = 0` and forces users to revoke with existing methods `revokeAllDelegates`, `revokeDelegate`, or the newly added methods `revokeForContract` and `revokeForToken`.