### PR TITLE
Contract and Token Enumeration

### DIFF
--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -26,6 +26,7 @@ import {ERC165} from "openzeppelin-contracts/contracts/utils/introspection/ERC16
 contract DelegationRegistry is IDelegationRegistry, ERC165 {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.Bytes32Set;
+    using EnumerableSet for EnumerableSet.UintSet;
 
     /// @notice The global mapping and single source of truth for delegations
     mapping(bytes32 => bool) internal delegations;
@@ -338,6 +339,20 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
                 mstore(delegates, sub(mload(delegates), decrease))
             }
         }
+    }
+
+    /**
+     * @inheritdoc IDelegationRegistry
+     */
+    function getContractsWithContractDelegations(address vault) external view returns (address[] memory contracts) {
+        revert("not implemented");
+    }
+
+    /**
+     * @inheritdoc IDelegationRegistry
+     */
+    function getTokensWithActiveTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds) {
+        revert("not implemented");
     }
 
     /**

--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -69,7 +69,8 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
 
     /// @notice A secondary mapping used to return onchain enumerability of a contract's tokens w/token-level delegations
     /// @dev vault -> vaultVersion -> contract -> tokens
-    mapping(address => mapping(uint256 => mapping(address => EnumerableSet.UintSet))) internal tokensWithTokenDelegations;
+    mapping(address => mapping(uint256 => mapping(address => EnumerableSet.UintSet))) internal
+        tokensWithTokenDelegations;
 
     /**
      * @inheritdoc ERC165
@@ -363,11 +364,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
     /**
      * @inheritdoc IDelegationRegistry
      */
-    function getContractsWithContractDelegations(address vault)
-        external
-        view
-        returns (address[] memory contracts)
-    {
+    function getContractsWithContractDelegations(address vault) external view returns (address[] memory contracts) {
         EnumerableSet.AddressSet storage potentialContracts =
             contractsWithContractDelegations[vault][vaultVersion[vault]];
         uint256 potentialContractsLength = potentialContracts.length();
@@ -393,11 +390,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
     /**
      * @dev helper function that returns if any delegates are active for a contract
      */
-    function _anyActiveDelegatesForContract(address vault, address contract_)
-        internal
-        view
-        returns (bool)
-    {
+    function _anyActiveDelegatesForContract(address vault, address contract_) internal view returns (bool) {
         EnumerableSet.AddressSet storage potentialDelegates =
             delegationsForContract[vault][vaultVersion[vault]][contract_];
         uint256 potentialDelegatesLength = potentialDelegates.length();
@@ -420,8 +413,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         view
         returns (address[] memory contracts, uint256[] memory tokenIds)
     {
-        EnumerableSet.AddressSet storage potentialContracts =
-            contractsWithTokenDelegations[vault][vaultVersion[vault]];
+        EnumerableSet.AddressSet storage potentialContracts = contractsWithTokenDelegations[vault][vaultVersion[vault]];
         // build potential delegates length by iterating over potential contracts
         uint256 potentialContractsLength = potentialContracts.length();
         uint256 potentialTokensLength = 0;
@@ -438,7 +430,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         tokenIds = new uint256[](potentialTokensLength);
         for (uint256 i = 0; i < potentialContractsLength;) {
             address contract_ = potentialContracts.at(i);
-            EnumerableSet.UintSet storage potentialTokens = 
+            EnumerableSet.UintSet storage potentialTokens =
                 tokensWithTokenDelegations[vault][vaultVersion[vault]][contract_];
             for (uint256 j = 0; j < potentialTokens.length();) {
                 uint256 token = potentialTokens.at(j);

--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -14,6 +14,7 @@ import {ERC165} from "openzeppelin-contracts/contracts/utils/introspection/ERC16
  * @custom:coauthor foobar (0xfoobar)
  * @custom:coauthor wwchung (manifoldxyz)
  * @custom:coauthor purplehat (artblocks)
+ * @custom:coauthor ryley-o (artblocks)
  * @custom:coauthor andy8052 (tessera)
  * @custom:coauthor punk6529 (open metaverse)
  * @custom:coauthor loopify (loopiverse)

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -134,7 +134,7 @@ interface IDelegationRegistry {
      * @return contracts Array of all token contracts a vault has active token-level delegations on. Aligned by index
      * with `tokenIds`.
      * @return tokenIds Array of all token ids a vault has active token-level delegations on. Aligned by index with
-     * `addresses`.
+     * `contracts`.
      */
     function getTokensWithTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds);
 

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -120,6 +120,23 @@ interface IDelegationRegistry {
         external
         view
         returns (address[] memory);
+    
+    /**
+     * @notice Returns an array of all contracts a vault has active contract-level delegations on
+     * @param vault The cold wallet who issued the delegation
+     * @return contracts Array of all contracts a vault has active contract-level delegations on
+     */
+    function getContractsWithContractDelegations(address vault) external view returns (address[] memory contracts);
+
+    /**
+     * @notice Returns an array of all tokens (contract + token id) a vault has active token-level delegations on
+     * @param vault The cold wallet who issued the delegation
+     * @return contracts Array of all token contracts a vault has active token-level delegations on. Aligned by index
+     * with `tokenIds`.
+     * @return tokenIds Array of all token ids a vault has active token-level delegations on. Aligned by index with
+     * `addresses`.
+     */
+    function getTokensWithActiveTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds);
 
     /**
      * @notice Returns true if the address is delegated to act on your behalf for all tokens

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -120,7 +120,7 @@ interface IDelegationRegistry {
         external
         view
         returns (address[] memory);
-    
+
     /**
      * @notice Returns an array of all contracts a vault has active contract-level delegations on
      * @param vault The cold wallet who issued the delegation
@@ -136,7 +136,10 @@ interface IDelegationRegistry {
      * @return tokenIds Array of all token ids a vault has active token-level delegations on. Aligned by index with
      * `contracts`.
      */
-    function getTokensWithTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds);
+    function getTokensWithTokenDelegations(address vault)
+        external
+        view
+        returns (address[] memory contracts, uint256[] memory tokenIds);
 
     /**
      * @notice Returns true if the address is delegated to act on your behalf for all tokens

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -136,7 +136,7 @@ interface IDelegationRegistry {
      * @return tokenIds Array of all token ids a vault has active token-level delegations on. Aligned by index with
      * `addresses`.
      */
-    function getTokensWithActiveTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds);
+    function getTokensWithTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds);
 
     /**
      * @notice Returns true if the address is delegated to act on your behalf for all tokens

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -375,7 +375,7 @@ contract DelegationRegistryTest is Test {
         // Read
         address[] memory contracts;
         uint256[] memory tokens;
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract0);
         assertEq(contracts.length, 1);
         assertTrue(tokens[0] == tokenId0);
@@ -385,7 +385,7 @@ contract DelegationRegistryTest is Test {
         reg.delegateForToken(delegate0, contract0, tokenId1, true);
 
         // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract0);
         assertEq(contracts.length, 2);
@@ -398,7 +398,7 @@ contract DelegationRegistryTest is Test {
         reg.delegateForToken(delegate0, contract0, tokenId0, false);
 
         // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract0);
         assertEq(contracts.length, 2);
@@ -410,7 +410,7 @@ contract DelegationRegistryTest is Test {
         reg.delegateForToken(delegate0, contract1, tokenId0, true);
 
         // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract0);
         assertEq(contracts[2], contract1);
@@ -424,7 +424,7 @@ contract DelegationRegistryTest is Test {
         reg.delegateForToken(delegate0, contract0, tokenId1, false);
 
         // // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract1);
         assertEq(contracts.length, 2);
@@ -436,7 +436,7 @@ contract DelegationRegistryTest is Test {
         reg.revokeDelegate(delegate1);
 
         // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract1);
         assertEq(contracts.length, 1);
         assertTrue(tokens[0] == tokenId0);
@@ -447,7 +447,7 @@ contract DelegationRegistryTest is Test {
         reg.revokeAllDelegates();
 
         // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts.length, 0);
         assertEq(tokens.length, 0);
     }


### PR DESCRIPTION
Add capability to enumerate which contracts and tokens have contract-level or token-level delegations, respectively.

This is an option to be compared vs. the solution presented in #25, both of which solve the enumeration issues discussed in #18.

The added enumeration capability enables users to fully understand their vault's current state without off-chain indexing. Without this enumeration capability, users may enumerate which delegations exist for a queried contract or token, but the set of all contracts or tokens with active delegations needed to be known a priori (presumably via off-chain indexing).

The main drawback with this approach are:
- Additional internal mappings add code complexity
- It adds substantial gas (~+20%-+70%) when calling the `delegateFor<level>` methods.

However, gas is unchanged for the `checkDelegateFor<level>` calls.

Cc @jakerockland 