### PR TITLE
Refactor and Add Enumerations

### DIFF
--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -26,6 +26,7 @@ import {ERC165} from "openzeppelin-contracts/contracts/utils/introspection/ERC16
 contract DelegationRegistry is IDelegationRegistry, ERC165 {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.Bytes32Set;
+    using EnumerableSet for EnumerableSet.UintSet;
 
     /// @notice The global mapping and single source of truth for delegations
     mapping(bytes32 => bool) internal delegations;
@@ -338,6 +339,20 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
                 mstore(delegates, sub(mload(delegates), decrease))
             }
         }
+    }
+
+    /**
+     * @inheritdoc IDelegationRegistry
+     */
+    function getContractsWithContractDelegations(address vault) external view returns (address[] memory contracts) {
+        revert("not implemented");
+    }
+
+    /**
+     * @inheritdoc IDelegationRegistry
+     */
+    function getTokensWithActiveTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds) {
+        revert("not implemented");
     }
 
     /**

--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -69,7 +69,8 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
 
     /// @notice A secondary mapping used to return onchain enumerability of a contract's tokens w/token-level delegations
     /// @dev vault -> vaultVersion -> contract -> tokens
-    mapping(address => mapping(uint256 => mapping(address => EnumerableSet.UintSet))) internal tokensWithTokenDelegations;
+    mapping(address => mapping(uint256 => mapping(address => EnumerableSet.UintSet))) internal
+        tokensWithTokenDelegations;
 
     /**
      * @inheritdoc ERC165
@@ -363,11 +364,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
     /**
      * @inheritdoc IDelegationRegistry
      */
-    function getContractsWithContractDelegations(address vault)
-        external
-        view
-        returns (address[] memory contracts)
-    {
+    function getContractsWithContractDelegations(address vault) external view returns (address[] memory contracts) {
         EnumerableSet.AddressSet storage potentialContracts =
             contractsWithContractDelegations[vault][vaultVersion[vault]];
         uint256 potentialContractsLength = potentialContracts.length();
@@ -393,11 +390,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
     /**
      * @dev helper function that returns if any delegates are active for a contract
      */
-    function _anyActiveDelegatesForContract(address vault, address contract_)
-        internal
-        view
-        returns (bool)
-    {
+    function _anyActiveDelegatesForContract(address vault, address contract_) internal view returns (bool) {
         EnumerableSet.AddressSet storage potentialDelegates =
             delegationsForContract[vault][vaultVersion[vault]][contract_];
         uint256 potentialDelegatesLength = potentialDelegates.length();
@@ -420,8 +413,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         view
         returns (address[] memory contracts, uint256[] memory tokenIds)
     {
-        EnumerableSet.AddressSet storage potentialContracts =
-            contractsWithTokenDelegations[vault][vaultVersion[vault]];
+        EnumerableSet.AddressSet storage potentialContracts = contractsWithTokenDelegations[vault][vaultVersion[vault]];
         // build potential delegates length by iterating over potential contracts
         uint256 potentialContractsLength = potentialContracts.length();
         uint256 potentialTokensLength = 0;
@@ -438,7 +430,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         tokenIds = new uint256[](potentialTokensLength);
         for (uint256 i = 0; i < potentialContractsLength;) {
             address contract_ = potentialContracts.at(i);
-            EnumerableSet.UintSet storage potentialTokens = 
+            EnumerableSet.UintSet storage potentialTokens =
                 tokensWithTokenDelegations[vault][vaultVersion[vault]][contract_];
             for (uint256 j = 0; j < potentialTokens.length();) {
                 uint256 token = potentialTokens.at(j);

--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -27,7 +27,6 @@ import {ERC165} from "openzeppelin-contracts/contracts/utils/introspection/ERC16
 contract DelegationRegistry is IDelegationRegistry, ERC165 {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.Bytes32Set;
-    using EnumerableSet for EnumerableSet.UintSet;
 
     /// @notice The global mapping and single source of truth for delegations
     /// @dev vault -> vaultVersion -> delegationHash

--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -14,6 +14,7 @@ import {ERC165} from "openzeppelin-contracts/contracts/utils/introspection/ERC16
  * @custom:coauthor foobar (0xfoobar)
  * @custom:coauthor wwchung (manifoldxyz)
  * @custom:coauthor purplehat (artblocks)
+ * @custom:coauthor ryley-o (artblocks)
  * @custom:coauthor andy8052 (tessera)
  * @custom:coauthor punk6529 (open metaverse)
  * @custom:coauthor loopify (loopiverse)

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -134,7 +134,7 @@ interface IDelegationRegistry {
      * @return contracts Array of all token contracts a vault has active token-level delegations on. Aligned by index
      * with `tokenIds`.
      * @return tokenIds Array of all token ids a vault has active token-level delegations on. Aligned by index with
-     * `addresses`.
+     * `contracts`.
      */
     function getTokensWithTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds);
 

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -19,6 +19,7 @@ interface IDelegationRegistry {
     struct DelegationInfo {
         DelegationType type_;
         address vault;
+        address delegate;
         address contract_;
         uint256 tokenId;
     }
@@ -122,24 +123,30 @@ interface IDelegationRegistry {
         returns (address[] memory);
 
     /**
-     * @notice Returns an array of all contracts a vault has active contract-level delegations on
+     * @notice Returns arrays defining all contract-level delegations
      * @param vault The cold wallet who issued the delegation
-     * @return contracts Array of all contracts a vault has active contract-level delegations on
+     * @return contracts Array of all contracts a vault has active contract-level delegations on. Aligned by index with
+     * `delegates`.
+     * @return delegates Array of delegates associated with `contracts`, aligned by index.
      */
-    function getContractsWithContractDelegations(address vault) external view returns (address[] memory contracts);
+    function getContractLevelDelegations(address vault)
+        external
+        view
+        returns (address[] memory contracts, address[] memory delegates);
 
     /**
-     * @notice Returns an array of all tokens (contract + token id) a vault has active token-level delegations on
+     * @notice Returns an array defining all token-level delegations
      * @param vault The cold wallet who issued the delegation
      * @return contracts Array of all token contracts a vault has active token-level delegations on. Aligned by index
      * with `tokenIds`.
      * @return tokenIds Array of all token ids a vault has active token-level delegations on. Aligned by index with
      * `contracts`.
+     * @return delegates Array of delegates associated with `contracts` and `tokenIds`, aligned by index.
      */
-    function getTokensWithTokenDelegations(address vault)
+    function getTokenLevelDelegations(address vault)
         external
         view
-        returns (address[] memory contracts, uint256[] memory tokenIds);
+        returns (address[] memory contracts, uint256[] memory tokenIds, address[] memory delegates);
 
     /**
      * @notice Returns true if the address is delegated to act on your behalf for all tokens

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -120,6 +120,23 @@ interface IDelegationRegistry {
         external
         view
         returns (address[] memory);
+    
+    /**
+     * @notice Returns an array of all contracts a vault has active contract-level delegations on
+     * @param vault The cold wallet who issued the delegation
+     * @return contracts Array of all contracts a vault has active contract-level delegations on
+     */
+    function getContractsWithContractDelegations(address vault) external view returns (address[] memory contracts);
+
+    /**
+     * @notice Returns an array of all tokens (contract + token id) a vault has active token-level delegations on
+     * @param vault The cold wallet who issued the delegation
+     * @return contracts Array of all token contracts a vault has active token-level delegations on. Aligned by index
+     * with `tokenIds`.
+     * @return tokenIds Array of all token ids a vault has active token-level delegations on. Aligned by index with
+     * `addresses`.
+     */
+    function getTokensWithActiveTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds);
 
     /**
      * @notice Returns true if the address is delegated to act on your behalf for all tokens

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -120,7 +120,7 @@ interface IDelegationRegistry {
         external
         view
         returns (address[] memory);
-    
+
     /**
      * @notice Returns an array of all contracts a vault has active contract-level delegations on
      * @param vault The cold wallet who issued the delegation
@@ -136,7 +136,10 @@ interface IDelegationRegistry {
      * @return tokenIds Array of all token ids a vault has active token-level delegations on. Aligned by index with
      * `contracts`.
      */
-    function getTokensWithTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds);
+    function getTokensWithTokenDelegations(address vault)
+        external
+        view
+        returns (address[] memory contracts, uint256[] memory tokenIds);
 
     /**
      * @notice Returns true if the address is delegated to act on your behalf for all tokens

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -136,7 +136,7 @@ interface IDelegationRegistry {
      * @return tokenIds Array of all token ids a vault has active token-level delegations on. Aligned by index with
      * `addresses`.
      */
-    function getTokensWithActiveTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds);
+    function getTokensWithTokenDelegations(address vault) external view returns (address[] memory contracts, uint256[] memory tokenIds);
 
     /**
      * @notice Returns true if the address is delegated to act on your behalf for all tokens

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -375,7 +375,7 @@ contract DelegationRegistryTest is Test {
         // Read
         address[] memory contracts;
         uint256[] memory tokens;
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract0);
         assertEq(contracts.length, 1);
         assertTrue(tokens[0] == tokenId0);
@@ -385,7 +385,7 @@ contract DelegationRegistryTest is Test {
         reg.delegateForToken(delegate0, contract0, tokenId1, true);
 
         // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract0);
         assertEq(contracts.length, 2);
@@ -398,7 +398,7 @@ contract DelegationRegistryTest is Test {
         reg.delegateForToken(delegate0, contract0, tokenId0, false);
 
         // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract0);
         assertEq(contracts.length, 2);
@@ -410,7 +410,7 @@ contract DelegationRegistryTest is Test {
         reg.delegateForToken(delegate0, contract1, tokenId0, true);
 
         // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract0);
         assertEq(contracts[2], contract1);
@@ -424,7 +424,7 @@ contract DelegationRegistryTest is Test {
         reg.delegateForToken(delegate0, contract0, tokenId1, false);
 
         // // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract1);
         assertEq(contracts.length, 2);
@@ -436,7 +436,7 @@ contract DelegationRegistryTest is Test {
         reg.revokeDelegate(delegate1);
 
         // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts[0], contract1);
         assertEq(contracts.length, 1);
         assertTrue(tokens[0] == tokenId0);
@@ -447,7 +447,7 @@ contract DelegationRegistryTest is Test {
         reg.revokeAllDelegates();
 
         // Read
-        (contracts, tokens)  = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
         assertEq(contracts.length, 0);
         assertEq(tokens.length, 0);
     }

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -272,7 +272,7 @@ contract DelegationRegistryTest is Test {
         assertEq(info[2].vault, vault0);
     }
 
-    function testContractLevelEnumeration(
+    function testContractLevelEnumerations(
         address vault,
         address delegate0,
         address delegate1,
@@ -294,62 +294,73 @@ contract DelegationRegistryTest is Test {
         reg.delegateForContract(delegate1, contract0, true);
 
         // Read
-        address[] memory contractsWithDelegations;
-        contractsWithDelegations = reg.getContractsWithContractDelegations(vault);
-        assertEq(contractsWithDelegations[0], contract0);
-        assertEq(contractsWithDelegations.length, 1);
+        address[] memory contracts;
+        address[] memory delegates;
+        (contracts, delegates) = reg.getContractLevelDelegations(vault);
+        assertEq(contracts.length, 2);
+        assertEq(contracts[0], contract0);
+        assertEq(contracts[1], contract0);
+        assertEq(delegates.length, contracts.length);
+        assertEq(delegates[0], delegate0);
+        assertEq(delegates[1], delegate1);
 
         // Delegate for another contract
         reg.delegateForContract(delegate0, contract1, true);
 
         // Read
-        contractsWithDelegations = reg.getContractsWithContractDelegations(vault);
-        assertTrue(contractsWithDelegations[0] == contract0 || contractsWithDelegations[0] == contract1);
-        assertTrue(contractsWithDelegations[1] == contract0 || contractsWithDelegations[1] == contract1);
-        assertEq(contractsWithDelegations.length, 2);
+        (contracts, delegates) = reg.getContractLevelDelegations(vault);
+        assertEq(contracts.length, 3);
+        assertEq(contracts[0], contract0);
+        assertEq(contracts[1], contract0);
+        assertEq(contracts[2], contract1);
+        assertEq(delegates.length, contracts.length);
+        assertEq(delegates[0], delegate0);
+        assertEq(delegates[1], delegate1);
+        assertEq(delegates[2], delegate0);
 
-        // Revoke duplicate
+        // Revoke single contract
         reg.delegateForContract(delegate0, contract0, false);
 
         // Read
-        contractsWithDelegations = reg.getContractsWithContractDelegations(vault);
-        assertTrue(contractsWithDelegations[0] == contract0 || contractsWithDelegations[0] == contract1);
-        assertTrue(contractsWithDelegations[1] == contract0 || contractsWithDelegations[1] == contract1);
-        assertTrue(contractsWithDelegations[0] != contractsWithDelegations[1]);
-        assertEq(contractsWithDelegations.length, 2);
-
-        // Revoke non-duplicate
-        reg.delegateForContract(delegate0, contract1, false);
-
-        // Read
-        contractsWithDelegations = reg.getContractsWithContractDelegations(vault);
-        assertEq(contractsWithDelegations[0], contract0);
-        assertEq(contractsWithDelegations.length, 1);
+        (contracts, delegates) = reg.getContractLevelDelegations(vault);
+        assertEq(contracts.length, 2);
+        assertEq(contracts[0], contract1);
+        assertEq(contracts[1], contract0);
+        assertEq(delegates.length, contracts.length);
+        assertEq(delegates[0], delegate0);
+        assertEq(delegates[1], delegate1);
 
         // Revoke Delegate
         reg.revokeDelegate(delegate1);
 
         // Read
-        contractsWithDelegations = reg.getContractsWithContractDelegations(vault);
-        assertEq(contractsWithDelegations.length, 0);
+        (contracts, delegates) = reg.getContractLevelDelegations(vault);
+        assertEq(contracts.length, 1);
+        assertEq(contracts[0], contract1);
+        assertEq(delegates.length, contracts.length);
+        assertEq(delegates[0], delegate0);
 
         // Add back delegate
-        reg.delegateForContract(delegate0, contract0, true);
+        reg.delegateForContract(delegate1, contract1, true);
 
         // Read
-        contractsWithDelegations = reg.getContractsWithContractDelegations(vault);
-        assertEq(contractsWithDelegations[0], contract0);
-        assertEq(contractsWithDelegations.length, 1);
+        (contracts, delegates) = reg.getContractLevelDelegations(vault);
+        assertEq(contracts.length, 2);
+        assertEq(contracts[0], contract1);
+        assertEq(contracts[1], contract1);
+        assertEq(delegates.length, contracts.length);
+        assertEq(delegates[0], delegate0);
+        assertEq(delegates[1], delegate1);
 
         // Revoke all
         reg.revokeAllDelegates();
 
         // Read
-        contractsWithDelegations = reg.getContractsWithContractDelegations(vault);
-        assertEq(contractsWithDelegations.length, 0);
+        (contracts, delegates) = reg.getContractLevelDelegations(vault);
+        assertEq(contracts.length, 0);
     }
 
-    function testTokenLevelEnumeration(
+    function testTokenLevelEnumerations(
         address vault,
         address delegate0,
         address delegate1,
@@ -374,81 +385,93 @@ contract DelegationRegistryTest is Test {
 
         // Read
         address[] memory contracts;
-        uint256[] memory tokens;
-        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
+        uint256[] memory tokenIds;
+        address[] memory delegates;
+        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
+        assertEq(contracts.length, 2);
         assertEq(contracts[0], contract0);
-        assertEq(contracts.length, 1);
-        assertTrue(tokens[0] == tokenId0);
-        assertEq(tokens.length, 1);
+        assertEq(contracts[1], contract0);
+        assertEq(tokenIds.length, contracts.length);
+        assertEq(tokenIds[0], tokenId0);
+        assertEq(tokenIds[1], tokenId0);
+        assertEq(delegates.length, contracts.length);
+        assertEq(delegates[0], delegate0);
+        assertEq(delegates[1], delegate1);
 
         // Delegate for another token
         reg.delegateForToken(delegate0, contract0, tokenId1, true);
 
         // Read
-        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
+        assertEq(contracts.length, 3);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract0);
-        assertEq(contracts.length, 2);
-        assertTrue(tokens[0] == tokenId0 || tokens[0] == tokenId1);
-        assertTrue(tokens[1] == tokenId0 || tokens[1] == tokenId1);
-        assertTrue(tokens[0] != tokens[1]);
-        assertEq(tokens.length, 2);
+        assertEq(contracts[2], contract0);
+        assertEq(tokenIds.length, contracts.length);
+        assertEq(tokenIds[0], tokenId0);
+        assertEq(tokenIds[1], tokenId0);
+        assertEq(tokenIds[2], tokenId1);
+        assertEq(delegates.length, contracts.length);
+        assertEq(delegates[0], delegate0);
+        assertEq(delegates[1], delegate1);
+        assertEq(delegates[2], delegate0);
 
-        // Revoke duplicate
+        // Revoke token
         reg.delegateForToken(delegate0, contract0, tokenId0, false);
 
         // Read
-        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
+        assertEq(contracts.length, 2);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract0);
-        assertEq(contracts.length, 2);
-        assertTrue(tokens[0] == tokenId0);
-        assertTrue(tokens[1] == tokenId1);
-        assertEq(tokens.length, 2);
+        assertEq(tokenIds.length, contracts.length);
+        assertEq(tokenIds[0], tokenId1);
+        assertEq(tokenIds[1], tokenId0);
+        assertEq(delegates.length, contracts.length);
+        assertEq(delegates[0], delegate0);
+        assertEq(delegates[1], delegate1);
 
         // Add token on different contract
         reg.delegateForToken(delegate0, contract1, tokenId0, true);
 
         // Read
-        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
+        assertEq(contracts.length, 3);
         assertEq(contracts[0], contract0);
         assertEq(contracts[1], contract0);
         assertEq(contracts[2], contract1);
-        assertEq(contracts.length, 3);
-        assertTrue(tokens[0] == tokenId0);
-        assertTrue(tokens[1] == tokenId1);
-        assertTrue(tokens[2] == tokenId0);
-        assertEq(tokens.length, 3);
-
-        // Revoke non-duplicate
-        reg.delegateForToken(delegate0, contract0, tokenId1, false);
-
-        // // Read
-        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
-        assertEq(contracts[0], contract0);
-        assertEq(contracts[1], contract1);
-        assertEq(contracts.length, 2);
-        assertTrue(tokens[0] == tokenId0);
-        assertTrue(tokens[1] == tokenId0);
-        assertEq(tokens.length, 2);
+        assertEq(tokenIds.length, contracts.length);
+        assertEq(tokenIds[0], tokenId1);
+        assertEq(tokenIds[1], tokenId0);
+        assertEq(tokenIds[2], tokenId0);
+        assertEq(delegates.length, contracts.length);
+        assertEq(delegates[0], delegate0);
+        assertEq(delegates[1], delegate1);
+        assertEq(delegates[2], delegate0);
 
         // Revoke Delegate
         reg.revokeDelegate(delegate1);
 
         // Read
-        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
-        assertEq(contracts[0], contract1);
-        assertEq(contracts.length, 1);
-        assertTrue(tokens[0] == tokenId0);
-        assertEq(tokens.length, 1);
+        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
+        assertEq(contracts.length, 2);
+        assertEq(contracts[0], contract0);
+        assertEq(contracts[1], contract1);
+        assertEq(tokenIds.length, contracts.length);
+        assertEq(tokenIds[0], tokenId1);
+        assertEq(tokenIds[1], tokenId0);
+        assertEq(delegates.length, contracts.length);
+        assertEq(delegates[0], delegate0);
+        assertEq(delegates[1], delegate0);
 
         // Add back delegate, then revoke all
         reg.delegateForToken(delegate1, contract0, tokenId0, true);
         reg.revokeAllDelegates();
 
         // Read
-        (contracts, tokens) = reg.getTokensWithTokenDelegations(vault);
+        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
         assertEq(contracts.length, 0);
-        assertEq(tokens.length, 0);
+        assertEq(tokenIds.length, contracts.length);
+        assertEq(delegates.length, contracts.length);
     }
 }


### PR DESCRIPTION
Refactor internal mappings to simplify code, and enable more helpful enumerations.

This is an option to be compared vs. the solution presented in #24, both of which solve the enumeration issues discussed in #18.

This:
- Refactors internal mappings to make delegation hashes enumerable by default, eliminating many internal secondary mappings (and their associated code complexity)
- Adds new enumerations that enable a user to fully understand their vault's current state without off-chain indexing:
  - `getContractLevelDelegations`
  - `getTokenLevelDelegations`
  - without these enumerations, users may enumerate which delegations exist for a queried contract or token, but the set of all contracts or tokens with active delegations could not be known without off-chain indexing

The main drawback with this approach is that it adds an average of ~200 gas to the `checkDelegateFor<level>` calls. Otherwise, it tends to be a bit more gas efficient than baseline for the `delegateFor<level>` calls, and much more efficient than #24 when calling the `delegateFor<level>` methods.

Cc @jakerockland 