### PR TITLE
Return structs instead of multiple arrays

### DIFF
--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -328,13 +328,12 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
     function getContractLevelDelegations(address vault)
         external
         view
-        returns (address[] memory contracts, address[] memory delegates)
+        returns (IDelegationRegistry.ContractDelegation[] memory contractDelegations)
     {
         EnumerableSet.Bytes32Set storage delegationHashes_ = delegations[vault][vaultVersion[vault]];
         uint256 potentialLength = delegationHashes_.length();
         uint256 delegationCount = 0;
-        contracts = new address[](potentialLength);
-        delegates = new address[](potentialLength);
+        contractDelegations = new IDelegationRegistry.ContractDelegation[](potentialLength);
         for (uint256 i = 0; i < potentialLength;) {
             bytes32 delegationHash = delegationHashes_.at(i);
             DelegationInfo storage delegationInfo_ = delegationInfo[delegationHash];
@@ -344,8 +343,10 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
                     delegationHash
                         == _computeContractDelegationHash(vault, delegationInfo_.delegate, delegationInfo_.contract_)
                 ) {
-                    contracts[delegationCount] = delegationInfo_.contract_;
-                    delegates[delegationCount++] = delegationInfo_.delegate;
+                    contractDelegations[delegationCount++] = IDelegationRegistry.ContractDelegation({
+                        contract_: delegationInfo_.contract_,
+                        delegate: delegationInfo_.delegate
+                    });
                 }
             }
             unchecked {
@@ -355,8 +356,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         if (potentialLength > delegationCount) {
             assembly {
                 let decrease := sub(potentialLength, delegationCount)
-                mstore(contracts, sub(mload(delegates), decrease))
-                mstore(delegates, sub(mload(delegates), decrease))
+                mstore(contractDelegations, sub(mload(contractDelegations), decrease))
             }
         }
     }
@@ -367,14 +367,12 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
     function getTokenLevelDelegations(address vault)
         external
         view
-        returns (address[] memory contracts, uint256[] memory tokenIds, address[] memory delegates)
+        returns (IDelegationRegistry.TokenDelegation[] memory tokenDelegations)
     {
         EnumerableSet.Bytes32Set storage delegationHashes_ = delegations[vault][vaultVersion[vault]];
         uint256 potentialLength = delegationHashes_.length();
         uint256 delegationCount = 0;
-        contracts = new address[](potentialLength);
-        tokenIds = new uint256[](potentialLength);
-        delegates = new address[](potentialLength);
+        tokenDelegations = new IDelegationRegistry.TokenDelegation[](potentialLength);
         for (uint256 i = 0; i < potentialLength;) {
             bytes32 delegationHash = delegationHashes_.at(i);
             DelegationInfo storage delegationInfo_ = delegationInfo[delegationHash];
@@ -384,9 +382,11 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
                     delegationHash
                         == _computeTokenDelegationHash(vault, delegationInfo_.delegate, delegationInfo_.contract_, delegationInfo_.tokenId)
                 ) {
-                    contracts[delegationCount] = delegationInfo_.contract_;
-                    tokenIds[delegationCount] = delegationInfo_.tokenId;
-                    delegates[delegationCount++] = delegationInfo_.delegate;
+                    tokenDelegations[delegationCount++] = IDelegationRegistry.TokenDelegation({
+                        contract_: delegationInfo_.contract_,
+                        tokenId: delegationInfo_.tokenId,
+                        delegate: delegationInfo_.delegate
+                    });
                 }
             }
             unchecked {
@@ -396,9 +396,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         if (potentialLength > delegationCount) {
             assembly {
                 let decrease := sub(potentialLength, delegationCount)
-                mstore(contracts, sub(mload(delegates), decrease))
-                mstore(tokenIds, sub(mload(delegates), decrease))
-                mstore(delegates, sub(mload(delegates), decrease))
+                mstore(tokenDelegations, sub(mload(tokenDelegations), decrease))
             }
         }
     }

--- a/src/DelegationRegistry.sol
+++ b/src/DelegationRegistry.sol
@@ -380,7 +380,9 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
                 // check delegate version by validating the hash
                 if (
                     delegationHash
-                        == _computeTokenDelegationHash(vault, delegationInfo_.delegate, delegationInfo_.contract_, delegationInfo_.tokenId)
+                        == _computeTokenDelegationHash(
+                            vault, delegationInfo_.delegate, delegationInfo_.contract_, delegationInfo_.tokenId
+                        )
                 ) {
                     tokenDelegations[delegationCount++] = IDelegationRegistry.TokenDelegation({
                         contract_: delegationInfo_.contract_,
@@ -421,7 +423,10 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
     {
         bytes32 delegateHash =
             keccak256(abi.encode(delegate, vault, contract_, vaultVersion[vault], delegateVersion[vault][delegate]));
-        return delegations[vault][vaultVersion[vault]].contains(delegateHash) ? true : checkDelegateForAll(delegate, vault);
+        return
+            delegations[vault][vaultVersion[vault]].contains(delegateHash)
+            ? true
+            : checkDelegateForAll(delegate, vault);
     }
 
     /**

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -24,6 +24,19 @@ interface IDelegationRegistry {
         uint256 tokenId;
     }
 
+    /// @notice Info about a single contract-level delegation
+    struct ContractDelegation {
+        address contract_;
+        address delegate;
+    }
+
+    /// @notice Info about a single token-level delegation
+    struct TokenDelegation {
+        address contract_;
+        uint256 tokenId;
+        address delegate;
+    }
+
     /// @notice Emitted when a user delegates their entire wallet
     event DelegateForAll(address vault, address delegate, bool value);
 
@@ -123,30 +136,21 @@ interface IDelegationRegistry {
         returns (address[] memory);
 
     /**
-     * @notice Returns arrays defining all contract-level delegations
-     * @param vault The cold wallet who issued the delegation
-     * @return contracts Array of all contracts a vault has active contract-level delegations on. Aligned by index with
-     * `delegates`.
-     * @return delegates Array of delegates associated with `contracts`, aligned by index.
+     * @notice Returns all contract-level delegations for a given vault
+     * @param vault The cold wallet who issued the delegations
+     * @return delegations Array of ContractDelegation structs
      */
     function getContractLevelDelegations(address vault)
         external
         view
-        returns (address[] memory contracts, address[] memory delegates);
+        returns (ContractDelegation[] memory delegations);
 
     /**
-     * @notice Returns an array defining all token-level delegations
-     * @param vault The cold wallet who issued the delegation
-     * @return contracts Array of all token contracts a vault has active token-level delegations on. Aligned by index
-     * with `tokenIds`.
-     * @return tokenIds Array of all token ids a vault has active token-level delegations on. Aligned by index with
-     * `contracts`.
-     * @return delegates Array of delegates associated with `contracts` and `tokenIds`, aligned by index.
+     * @notice Returns all token-level delegations for a given vault
+     * @param vault The cold wallet who issued the delegations
+     * @return delegations Array of TokenDelegation structs
      */
-    function getTokenLevelDelegations(address vault)
-        external
-        view
-        returns (address[] memory contracts, uint256[] memory tokenIds, address[] memory delegates);
+    function getTokenLevelDelegations(address vault) external view returns (TokenDelegation[] memory delegations);
 
     /**
      * @notice Returns true if the address is delegated to act on the entire vault

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -294,70 +294,64 @@ contract DelegationRegistryTest is Test {
         reg.delegateForContract(delegate1, contract0, true);
 
         // Read
-        address[] memory contracts;
-        address[] memory delegates;
-        (contracts, delegates) = reg.getContractLevelDelegations(vault);
-        assertEq(contracts.length, 2);
-        assertEq(contracts[0], contract0);
-        assertEq(contracts[1], contract0);
-        assertEq(delegates.length, contracts.length);
-        assertEq(delegates[0], delegate0);
-        assertEq(delegates[1], delegate1);
+        IDelegationRegistry.ContractDelegation[] memory contractDelegations;
+        contractDelegations = reg.getContractLevelDelegations(vault);
+        assertEq(contractDelegations.length, 2);
+        assertEq(contractDelegations[0].contract_, contract0);
+        assertEq(contractDelegations[1].contract_, contract0);
+        assertEq(contractDelegations[0].delegate, delegate0);
+        assertEq(contractDelegations[1].delegate, delegate1);
 
         // Delegate for another contract
         reg.delegateForContract(delegate0, contract1, true);
 
         // Read
-        (contracts, delegates) = reg.getContractLevelDelegations(vault);
-        assertEq(contracts.length, 3);
-        assertEq(contracts[0], contract0);
-        assertEq(contracts[1], contract0);
-        assertEq(contracts[2], contract1);
-        assertEq(delegates.length, contracts.length);
-        assertEq(delegates[0], delegate0);
-        assertEq(delegates[1], delegate1);
-        assertEq(delegates[2], delegate0);
+        contractDelegations = reg.getContractLevelDelegations(vault);
+        assertEq(contractDelegations.length, 3);
+        assertEq(contractDelegations[0].contract_, contract0);
+        assertEq(contractDelegations[1].contract_, contract0);
+        assertEq(contractDelegations[2].contract_, contract1);
+        assertEq(contractDelegations[0].delegate, delegate0);
+        assertEq(contractDelegations[1].delegate, delegate1);
+        assertEq(contractDelegations[2].delegate, delegate0);
 
         // Revoke single contract
         reg.delegateForContract(delegate0, contract0, false);
 
         // Read
-        (contracts, delegates) = reg.getContractLevelDelegations(vault);
-        assertEq(contracts.length, 2);
-        assertEq(contracts[0], contract1);
-        assertEq(contracts[1], contract0);
-        assertEq(delegates.length, contracts.length);
-        assertEq(delegates[0], delegate0);
-        assertEq(delegates[1], delegate1);
+        contractDelegations = reg.getContractLevelDelegations(vault);
+        assertEq(contractDelegations.length, 2);
+        assertEq(contractDelegations[0].contract_, contract1);
+        assertEq(contractDelegations[1].contract_, contract0);
+        assertEq(contractDelegations[0].delegate, delegate0);
+        assertEq(contractDelegations[1].delegate, delegate1);
 
         // Revoke Delegate
         reg.revokeDelegate(delegate1);
 
         // Read
-        (contracts, delegates) = reg.getContractLevelDelegations(vault);
-        assertEq(contracts.length, 1);
-        assertEq(contracts[0], contract1);
-        assertEq(delegates.length, contracts.length);
-        assertEq(delegates[0], delegate0);
+        contractDelegations = reg.getContractLevelDelegations(vault);
+        assertEq(contractDelegations.length, 1);
+        assertEq(contractDelegations[0].contract_, contract1);
+        assertEq(contractDelegations[0].delegate, delegate0);
 
         // Add back delegate
         reg.delegateForContract(delegate1, contract1, true);
 
         // Read
-        (contracts, delegates) = reg.getContractLevelDelegations(vault);
-        assertEq(contracts.length, 2);
-        assertEq(contracts[0], contract1);
-        assertEq(contracts[1], contract1);
-        assertEq(delegates.length, contracts.length);
-        assertEq(delegates[0], delegate0);
-        assertEq(delegates[1], delegate1);
+        contractDelegations = reg.getContractLevelDelegations(vault);
+        assertEq(contractDelegations.length, 2);
+        assertEq(contractDelegations[0].contract_, contract1);
+        assertEq(contractDelegations[1].contract_, contract1);
+        assertEq(contractDelegations[0].delegate, delegate0);
+        assertEq(contractDelegations[1].delegate, delegate1);
 
         // Revoke all
         reg.revokeAllDelegates();
 
         // Read
-        (contracts, delegates) = reg.getContractLevelDelegations(vault);
-        assertEq(contracts.length, 0);
+        contractDelegations = reg.getContractLevelDelegations(vault);
+        assertEq(contractDelegations.length, 0);
     }
 
     function testTokenLevelEnumerations(
@@ -384,94 +378,80 @@ contract DelegationRegistryTest is Test {
         reg.delegateForToken(delegate1, contract0, tokenId0, true);
 
         // Read
-        address[] memory contracts;
-        uint256[] memory tokenIds;
-        address[] memory delegates;
-        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
-        assertEq(contracts.length, 2);
-        assertEq(contracts[0], contract0);
-        assertEq(contracts[1], contract0);
-        assertEq(tokenIds.length, contracts.length);
-        assertEq(tokenIds[0], tokenId0);
-        assertEq(tokenIds[1], tokenId0);
-        assertEq(delegates.length, contracts.length);
-        assertEq(delegates[0], delegate0);
-        assertEq(delegates[1], delegate1);
+        IDelegationRegistry.TokenDelegation[] memory tokenDelegations;
+        tokenDelegations = reg.getTokenLevelDelegations(vault);
+        assertEq(tokenDelegations.length, 2);
+        assertEq(tokenDelegations[0].contract_, contract0);
+        assertEq(tokenDelegations[1].contract_, contract0);
+        assertEq(tokenDelegations[0].tokenId, tokenId0);
+        assertEq(tokenDelegations[1].tokenId, tokenId0);
+        assertEq(tokenDelegations[0].delegate, delegate0);
+        assertEq(tokenDelegations[1].delegate, delegate1);
 
         // Delegate for another token
         reg.delegateForToken(delegate0, contract0, tokenId1, true);
 
         // Read
-        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
-        assertEq(contracts.length, 3);
-        assertEq(contracts[0], contract0);
-        assertEq(contracts[1], contract0);
-        assertEq(contracts[2], contract0);
-        assertEq(tokenIds.length, contracts.length);
-        assertEq(tokenIds[0], tokenId0);
-        assertEq(tokenIds[1], tokenId0);
-        assertEq(tokenIds[2], tokenId1);
-        assertEq(delegates.length, contracts.length);
-        assertEq(delegates[0], delegate0);
-        assertEq(delegates[1], delegate1);
-        assertEq(delegates[2], delegate0);
+        tokenDelegations = reg.getTokenLevelDelegations(vault);
+        assertEq(tokenDelegations.length, 3);
+        assertEq(tokenDelegations[0].contract_, contract0);
+        assertEq(tokenDelegations[1].contract_, contract0);
+        assertEq(tokenDelegations[2].contract_, contract0);
+        assertEq(tokenDelegations[0].tokenId, tokenId0);
+        assertEq(tokenDelegations[1].tokenId, tokenId0);
+        assertEq(tokenDelegations[2].tokenId, tokenId1);
+        assertEq(tokenDelegations[0].delegate, delegate0);
+        assertEq(tokenDelegations[1].delegate, delegate1);
+        assertEq(tokenDelegations[2].delegate, delegate0);
 
         // Revoke token
         reg.delegateForToken(delegate0, contract0, tokenId0, false);
 
         // Read
-        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
-        assertEq(contracts.length, 2);
-        assertEq(contracts[0], contract0);
-        assertEq(contracts[1], contract0);
-        assertEq(tokenIds.length, contracts.length);
-        assertEq(tokenIds[0], tokenId1);
-        assertEq(tokenIds[1], tokenId0);
-        assertEq(delegates.length, contracts.length);
-        assertEq(delegates[0], delegate0);
-        assertEq(delegates[1], delegate1);
+        tokenDelegations = reg.getTokenLevelDelegations(vault);
+        assertEq(tokenDelegations.length, 2);
+        assertEq(tokenDelegations[0].contract_, contract0);
+        assertEq(tokenDelegations[1].contract_, contract0);
+        assertEq(tokenDelegations[0].tokenId, tokenId1);
+        assertEq(tokenDelegations[1].tokenId, tokenId0);
+        assertEq(tokenDelegations[0].delegate, delegate0);
+        assertEq(tokenDelegations[1].delegate, delegate1);
 
         // Add token on different contract
         reg.delegateForToken(delegate0, contract1, tokenId0, true);
 
         // Read
-        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
-        assertEq(contracts.length, 3);
-        assertEq(contracts[0], contract0);
-        assertEq(contracts[1], contract0);
-        assertEq(contracts[2], contract1);
-        assertEq(tokenIds.length, contracts.length);
-        assertEq(tokenIds[0], tokenId1);
-        assertEq(tokenIds[1], tokenId0);
-        assertEq(tokenIds[2], tokenId0);
-        assertEq(delegates.length, contracts.length);
-        assertEq(delegates[0], delegate0);
-        assertEq(delegates[1], delegate1);
-        assertEq(delegates[2], delegate0);
+        tokenDelegations = reg.getTokenLevelDelegations(vault);
+        assertEq(tokenDelegations.length, 3);
+        assertEq(tokenDelegations[0].contract_, contract0);
+        assertEq(tokenDelegations[1].contract_, contract0);
+        assertEq(tokenDelegations[2].contract_, contract1);
+        assertEq(tokenDelegations[0].tokenId, tokenId1);
+        assertEq(tokenDelegations[1].tokenId, tokenId0);
+        assertEq(tokenDelegations[2].tokenId, tokenId0);
+        assertEq(tokenDelegations[0].delegate, delegate0);
+        assertEq(tokenDelegations[1].delegate, delegate1);
+        assertEq(tokenDelegations[2].delegate, delegate0);
 
         // Revoke Delegate
         reg.revokeDelegate(delegate1);
 
         // Read
-        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
-        assertEq(contracts.length, 2);
-        assertEq(contracts[0], contract0);
-        assertEq(contracts[1], contract1);
-        assertEq(tokenIds.length, contracts.length);
-        assertEq(tokenIds[0], tokenId1);
-        assertEq(tokenIds[1], tokenId0);
-        assertEq(delegates.length, contracts.length);
-        assertEq(delegates[0], delegate0);
-        assertEq(delegates[1], delegate0);
+        tokenDelegations = reg.getTokenLevelDelegations(vault);
+        assertEq(tokenDelegations.length, 2);
+        assertEq(tokenDelegations[0].contract_, contract0);
+        assertEq(tokenDelegations[1].contract_, contract1);
+        assertEq(tokenDelegations[0].tokenId, tokenId1);
+        assertEq(tokenDelegations[1].tokenId, tokenId0);
+        assertEq(tokenDelegations[0].delegate, delegate0);
+        assertEq(tokenDelegations[1].delegate, delegate0);
 
         // Add back delegate, then revoke all
         reg.delegateForToken(delegate1, contract0, tokenId0, true);
         reg.revokeAllDelegates();
 
         // Read
-        (contracts, tokenIds, delegates) = reg.getTokenLevelDelegations(vault);
-        assertEq(contracts.length, 0);
-        assertEq(tokenIds.length, contracts.length);
-        assertEq(delegates.length, contracts.length);
+        tokenDelegations = reg.getTokenLevelDelegations(vault);
+        assertEq(tokenDelegations.length, 0);
     }
 }


### PR DESCRIPTION
Return structs from contract-level and token-level enumeration functions.

Based on feedback from @wwhchung 